### PR TITLE
feat: early stopping & ds/model download

### DIFF
--- a/download.py
+++ b/download.py
@@ -1,0 +1,32 @@
+from datasets import load_dataset
+from transformers import BertTokenizerFast, BertForMaskedLM
+from argparse import ArgumentParser
+
+def download(args):
+    print("Downloading datasets and models...")
+    if args.lang == "yue":
+        print("Downloading Cantonese Wiki dataset...")
+        ds = load_dataset("R5dwMg/zh-wiki-yue-long")
+        ds.save_to_disk("./yue-wiki-local")
+        print("Downloading BERT tokenizer and model...")
+        BertTokenizerFast.from_pretrained('bert-base-chinese').save_pretrained(args.model_dir)
+    elif args.lang == "wuu":
+        print("Downloading Wu Wiki dataset...")
+        ds = load_dataset("wikimedia/wikipedia", "20231101.wuu")
+        ds.save_to_disk("./wuu-wiki-local")
+        print("Downloading BERT tokenizer...")
+        BertTokenizerFast.from_pretrained('bert-base-chinese').save_pretrained(args.model_dir)
+    else:
+        print(f"{args.lang} is not supported. Please choose from: yue, wuu")
+        return
+    print("Downloading BERT model...")
+    BertForMaskedLM.from_pretrained('bert-base-chinese').save_pretrained(args.model_dir)
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("--lang", default="yue", choices=["yue", "wuu"],
+                        help="Language to download data for")
+    parser.add_argument("--model_dir", default="./bert-base-chinese-local",
+                        help="Directory to save the model and tokenizer")
+    args = parser.parse_args()
+    download(args)

--- a/run.py
+++ b/run.py
@@ -3,10 +3,10 @@ from argparse import ArgumentParser
 
 def run(args):
     if args.lang == "yue":
-        model = CantoPreTrainer()
+        model = CantoPreTrainer(model_dir=args.model_dir)
         model.train()
     elif args.lang == "wuu":
-        model = WuPreTrainer()
+        model = WuPreTrainer(model_dir=args.model_dir)
         model.train()
     else:
         print(f"{args.lang} is not supported. Please choose from: yue, wuu")
@@ -14,5 +14,6 @@ def run(args):
 if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument("--lang", default="yue")
+    parser.add_argument("--model_dir", default="./bert-base-chinese-local")
     args = parser.parse_args()
     run(args)


### PR DESCRIPTION
changes:
- implemented early stopping
- in canto & wu pre-trainers, create 10% valid set out of train set
- added `model_dir` as an attribute of pre-trainer class, so users can specify custom (location of) model
- implemented `download.py` for downloading model & yue/wu datasets
- error checking for presence of train/valid sets & presence of model & ds directories

![1446cc37d091e3073040f3b2dcdce218](https://github.com/user-attachments/assets/28925d5b-7dab-4cf1-bd5b-75264af0e262)
